### PR TITLE
Fix/useGifs -  validation so that the localStorage always has a searc…

### DIFF
--- a/src/hooks/useGifs.js
+++ b/src/hooks/useGifs.js
@@ -22,7 +22,7 @@ export function useGifs ({ keyword, rating } = { keyword: null }) {
         setGifs(gifs)
         setLoading(false)
         // guardamos la keyword en el localStorage
-        localStorage.setItem('lastKeyword', keyword)
+        gifs.length && localStorage.setItem('lastKeyword', keywordToUse)
       })
   }, [keyword, keywordToUse, rating, setGifs])
 


### PR DESCRIPTION
Cuando se realiza una búsqueda ejemplo: dinosario no trae resultados, lo que significa que el keyword del localstorage al volver al home la vista de últimos resultados queda en blanco . Se agrego una validación para evitarlo y que siempre haya una vista de gifs en el home.